### PR TITLE
Missing ReLU in the last Conv

### DIFF
--- a/model.py
+++ b/model.py
@@ -144,7 +144,7 @@ def SqueezeNet(nb_classes, inputs=(3, 224, 224)):
 
     fire9_dropout = Dropout(0.5, name='fire9_dropout')(merge9)
     conv10 = Convolution2D(
-        nb_classes, (1, 1), kernel_initializer='glorot_uniform',
+        nb_classes, (1, 1), activation='relu', kernel_initializer='glorot_uniform',
         padding='valid', name='conv10',
         data_format="channels_first")(fire9_dropout)
 


### PR DESCRIPTION
I came across your repo from the [official repository](https://github.com/DeepScale/SqueezeNet) and I was finding some differences between the expected results and this implementation. It turned out the missing piece was a `ReLU` in the last convolutional layer: `conv10`. The ReLU is in the original implementation (Caffe, both SqueezeNets 1.0 and 1.1) and, as your repository is recommended by them, it would be fair to have it here too. With this simple modification, I'm achieving exactly the same results using both Caffe and your Keras-based implementation. BTW, thanks for the effort!